### PR TITLE
Update to the side menu

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -378,6 +378,11 @@ function SidebarCollapse () {
                   </div>
                 </a>
                 <div id="contact" class="collapse sidebar-submenu" data-parent="#accounting">
+                  <a id="accounting_contact_read_all" href="{{ url_for('accounting_contact_read_all') }}" class="list-group-item list-group-item-action bg-dark text-white">
+                    <span class="fa fa-user fa-fw mr-3"></span>
+                    <span class="fa fa-user fa-fw mr-3"></span>
+                    <span class="menu-collapsed">Read (all)</span>
+                  </a>
                   <a id="accounting_contact_create" href="{{ url_for('accounting_contact_create') }}" class="list-group-item list-group-item-action bg-dark text-white">
                       <span class="fa fa-user fa-fw mr-3"></span>
                       <span class="fa fa-user fa-fw mr-3"></span>
@@ -387,11 +392,6 @@ function SidebarCollapse () {
                       <span class="fa fa-user fa-fw mr-3"></span>
                       <span class="fa fa-user fa-fw mr-3"></span>
                       <span class="menu-collapsed">Create (multiple)</span>
-                  </a>
-                  <a id="accounting_contact_read_all" href="{{ url_for('accounting_contact_read_all') }}" class="list-group-item list-group-item-action bg-dark text-white">
-                        <span class="fa fa-user fa-fw mr-3"></span>
-                        <span class="fa fa-user fa-fw mr-3"></span>
-                        <span class="menu-collapsed">Read (all)</span>
                   </a>
                 </div>
 


### PR DESCRIPTION
Reordered 'Read (all)', to the top of the collapsable menu to match the layout of other endpoints.