### PR TITLE
xero-python-oauth2-app  Scope Checking Warning Flag fix

### DIFF
--- a/app.py
+++ b/app.py
@@ -42,6 +42,7 @@ dictConfig(logging_settings.default_settings)
 app = Flask(__name__)
 app.config.from_object("default_settings")
 app.config.from_pyfile("config.py", silent=True)
+os.environ['OAUTHLIB_RELAX_TOKEN_SCOPE'] = '1'
 
 if app.config["ENV"] != "production":
     # allow oauth2 loop to run over http (used for local testing only)


### PR DESCRIPTION
https://www.rfc-editor.org/rfc/rfc6749#section-3.3

OAuth library reference:  https://github.com/oauthlib/oauthlib/blob/564d526fdbdc32a936e4b5ddac186c26024f626b/oauthlib/oauth2/rfc6749/parameters.py#L466

**Security considerations**

Setting this variable indicates to Google to return different OAuth scopes than requested; Google is known to do this sometimes. IBM utilise this flag in OneDrive StoredIQ in production server instances. Reference:

https://www.ibm.com/support/pages/system/files/inline-files/$FILE/IBMSIQAdministratorAdminGuide76018.pdf