### PR TITLE
Pin flask version for session_cookie_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Currently state is required. An empty string is not valid.
 ## Take it for a spin
 
 * Make sure your python virtual environment activated `source venv/bin/activate`
+* Install packages the app is dependent on `pip install -r requirements.txt`
 * Start flask application `python3 app.py`
 * Launch your browser and navigate to http://localhost:5000/login 
 * You should be redirected to Xero login page.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-flask
+flask<2.3.0
 flask-session==0.3.2
 flask-oauthlib==0.9.6
 xero-python==v1.19.0


### PR DESCRIPTION
* Update readme for installing dependencies
* Pin flask version

Running the project from clean slate causes this error:

> AttributeError: 'Flask' object has no attribute 'session_cookie_name'

[Flask changelog](https://github.com/pallets/flask/blob/cb825687a592709f902f3d320d93987a0546fd28/CHANGES.rst#L44) indicates:

> The session_cookie_name, send_file_max_age_default, use_x_sendfile, propagate_exceptions, and templates_auto_reload properties on app are removed.